### PR TITLE
Adapt makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,5 +16,4 @@ build:
 	gcc -ggdb -std=gnu99 -Wall -Wextra -o microscheme src/*.c
 
 install:
-	sudo install -m755 ./microscheme /usr/local/bin
-
+	install -m755 ./microscheme /usr/local/bin

--- a/makefile
+++ b/makefile
@@ -2,6 +2,8 @@
 # (C) 2014 Ryan Suchocki
 # microscheme.org
 
+PREFIX?=/usr/local
+
 all: hexify build
 
 hexify:
@@ -16,4 +18,4 @@ build:
 	gcc -ggdb -std=gnu99 -Wall -Wextra -o microscheme src/*.c
 
 install:
-	install -m755 ./microscheme /usr/local/bin
+	install -m755 ./microscheme $(PREFIX)/bin


### PR DESCRIPTION
It was suggested to me to propose you some improvments on the makefile:

- As you already suggest using `sudo` when calling the makefile target
  `install`, there is no need for it inside the makefile. (not every
  distribution uses it)

- Also not all distribution use /usr/local/bin folder scheme.
  Permitting this override would broaden uses in more distributions.

Do you think it's possible to integrate those changes?

Reference: https://github.com/NixOS/nixpkgs/pull/6342#issuecomment-74415555

Thanks in advance.

*Note*
Thanks for microscheme!

Cheers,