### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Microscheme currently supports the ATMega168/328 (used on the Arduino UNO), the 
 
 Note: An Arduino Pro Mini with a 168/328 chip (programmed via an UNO board with its chip removed) can be treated as an UNO, because it uses the same chip.
 
-Other chips could be supported by writing header files to match [MEGA.s](src/MEGA.s) and [UNO.s](src/UNO.s), which contain values derived from the relevant Atmel datasheet. You will also need to add extra cases to the makefile, codegen.c and main.c to accomodate the new model.
+Other chips could be supported by writing header files to match [MEGA.s](src/MEGA.s) and [UNO.s](src/UNO.s), which contain values derived from the relevant Atmel datasheet. You will also need to add extra cases to the makefile, codegen.c and main.c to accommodate the new model.
 
 Compiler pipeline
 -----------------


### PR DESCRIPTION
@ryansuchocki, I've corrected a typographical error in the documentation of the [microscheme](https://github.com/ryansuchocki/microscheme) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.