### PR TITLE
Add plain ATmega32 model.

### DIFF
--- a/src/models.c
+++ b/src/models.c
@@ -84,6 +84,33 @@ model_info models[] = {
 		".EQU	P13,	7		\n"
 
 		".EQU	_ms_stack,	__stack\n"
+	},
+	{
+		"ATmega32",
+
+		"atmega32",
+		"avrispmkii",
+		"115200",
+
+		false,
+
+		// diagnostic output is PORTC7
+		".EQU	PORT13,	0x15	\n"
+		".EQU	DDR13,	0x14	\n"
+		".EQU	P13,	7		\n"
+
+		".EQU	_ms_stack,	__stack\n"
+
+		".EQU	UDR0,	0x2C	\n"
+		".EQU	UBRR0H,	0x40	\n"
+		".EQU	UBRR0L,	0x29	\n"
+		".EQU	UCSR0B,	0x2A	\n"
+		".EQU	UCSR0A,	0x2B	\n"
+		".EQU	TXEN0,	3		\n"
+		".EQU	RXEN0,	4		\n"
+		".EQU	UDRE0,	5		\n"
+		".EQU	TXC0,	6		\n"
+		".EQU	RXC0,	7		\n"
 	}
 };
 

--- a/src/stdlib.ms
+++ b/src/stdlib.ms
@@ -109,6 +109,18 @@
 (define arduino-ports)
 (define arduino-pins)
 
+;; A = #x39, B = #x36, C = #x33, D = #x30
+(@if-model "ATmega32"
+	(begin
+		(set! arduino-ports	(vector #x39	#x39	#x39	#x39	#x39	#x39	#x39	#x39
+									#x36	#x36	#x36	#x36	#x36	#x36	#x36	#x36
+									#x33	#x33	#x33	#x33	#x33	#x33	#x33	#x33
+									#x30	#x30	#x30	#x30	#x30	#x30	#x30	#x30))
+		(set! arduino-pins	(vector 1 2 4 8 16 32 64 128
+									1 2 4 8 16 32 64 128
+									1 2 4 8 16 32 64 128
+									1 2 4 8 16 32 64 128))))
+
 (@if-model "MEGA"
 	(begin
 		(set! arduino-ports	(vector #x2C	#x2C	#x2C	#x2C	#x32	#x2C	#x100	#x100


### PR DESCRIPTION
This adds a new ATmega32 model for non Arduino boards.  The pin mappings expose all pins from ports A, B, C, and D.  PORTC7 is used as the diagnosis LED pin (on the RN-control board all pins of PORTC are connected to LEDs).

This works for my RN-control board with an ATmega32.