### PR TITLE
Make `make install` compatible with BSD install

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ build:
 	gcc -ggdb -std=gnu99 -Wall -Wextra -o microscheme src/*.c
 
 install:
-	install -Dm755 ./microscheme $(PREFIX)/bin/microscheme
+	install -d $(PREFIX)/bin/
+	install -m755 ./microscheme $(PREFIX)/bin/microscheme
 	install -d $(PREFIX)/share/microscheme/
 	cp -r examples/ $(PREFIX)/share/microscheme/


### PR DESCRIPTION
BSD `install` (e.g. on OS X) does not support `-D`. FreeBSD `install` does have `-D`, but its meaning is different than GNU `install`’s.