### PR TITLE
Add SRFI-43-compliant vector-copy!.

### DIFF
--- a/src/stdlib.ms
+++ b/src/stdlib.ms
@@ -323,7 +323,16 @@
 				(for-each-vector writer right)
 				destination))))
 
+;; for backwards-compatibility, this is the old version
 (define (vector-copy src dest src-start src-finish dest-start)
+	(if (> src-start src-finish)
+		dest
+		(begin
+			(vector-set! dest dest-start (vector-ref src src-start))
+			(vector-copy src dest (+ src-start 1) src-finish (+ dest-start 1)))))
+
+;; this is the SRFI-43-compliant version
+(define (vector-copy! dest dest-start src src-start src-finish)
 	(if (> src-start src-finish)
 		dest
 		(begin


### PR DESCRIPTION
This lets me load microscheme code into racket for testing, which is
super handy! (The SRFI version allows some of the args to be optional,
which we don't support, but I think it's still worth adding.)

I kept the old vector-copy with the non-standard argument order for
backwards-compatibility reasons.