### PR TITLE
Implement when by cribbing from if and begin.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -81,6 +81,16 @@ void codegen_emit(AST_expr *expr, int parent_numArgs, FILE *outputFile) {
 			fprintf(outputFile, "if_end%i:\n", label1);
 			break;
 
+        case When:
+			label1 = if_end_unique++;
+			codegen_emit(expr->body[0], parent_numArgs, outputFile);
+			fprintf(outputFile, "\tCP CRSh, falseReg\n\tBREQ if_end%i\n", label1);
+			for (i=1; i<expr->numBody; i++) {
+				codegen_emit(expr->body[i], parent_numArgs, outputFile);
+			}
+			fprintf(outputFile, "if_end%i:\n", label1);
+			break;
+
 		case And:
 			label1 = and_end_unique++;
 			for (i=0; i<expr->numBody-1; i++) {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -12,7 +12,7 @@ extern bool opt_verbose;
 
 int fileLine = 1;
 
-char* keywords[] = {"lambda", "if", "let", "set!", "define", "begin", "and", "or", "include", "free!", "@if-model", "list","vector", "call-c-func", "include-asm", "asm"};
+char* keywords[] = {"lambda", "if", "when", "let", "set!", "define", "begin", "and", "or", "include", "free!", "@if-model", "list","vector", "call-c-func", "include-asm", "asm"};
 int keywordsi = sizeof(keywords) / sizeof(char*);
 
 char* primwords[] = {	"=", ">", ">=", "<", "<=", "not", "¬", "eq?",

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -5,7 +5,7 @@
 
 // Type definitions
 	enum lexer_tokenNodeType {Keyword, Primword, Numerictoken, Identifier, Stringtoken, Booleantoken, Chartoken, Parens, Nulltoken };  
-	enum keywordtype {lambda, ifword, let, set, define, begin, andword, orword, includeword, freeword, ifmodelword, listword, vectorword, callcfuncword, includeasmword, asmword};
+	enum keywordtype {lambda, ifword, when, let, set, define, begin, andword, orword, includeword, freeword, ifmodelword, listword, vectorword, callcfuncword, includeasmword, asmword};
 	typedef struct lexer_tokenNode {enum lexer_tokenNodeType type; enum keywordtype keyword; char *raw; 
 		struct lexer_tokenNode **children; int numChildren; struct lexer_tokenNode *parent; int fileLine;} lexer_tokenNode;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -172,6 +172,22 @@ AST_expr *parser_parseExpr(lexer_tokenNode **token, int numTokens, bool topLevel
 								//DEBUG printf("Conditional Branch"); 
 								break;
 
+							case when:
+							    result->type = When;
+								if (innerNumTokens > 2) {
+									result->numBody = innerNumTokens-1;
+									result->body = try_malloc(sizeof(AST_expr*) * (innerNumTokens-1));
+									for (i=1; i<innerNumTokens - 1; i++) {
+									    result->body[i-1] = parser_parseExpr(&innerTokens[i], 1, false, false);
+									}
+
+									result->body[innerNumTokens-2] = parser_parseExpr(&innerTokens[innerNumTokens-1], 1, false, tailPosition);
+								} else {
+									fprintf(stderr, ">> ERROR 9: Wrong number of operands to WHEN form");
+									exit(EXIT_FAILURE);
+								}
+								break;
+
 							case andword:
 								if (innerNumTokens == 1) {
 									c = try_malloc(sizeof(AST_const)); 

--- a/src/parser.h
+++ b/src/parser.h
@@ -6,7 +6,7 @@
 // Type definitions
 	enum AST_constType { Booleanconst, Charconst, Stringconst, Numconst, Emptylistconst };
 	typedef struct AST_const { enum AST_constType type;	int value; char *strvalue;} AST_const;
-	enum AST_exprType { Constant, Variable, Lambda, Branch, Definition, Assignment, Sequence, ProcCall, And, Or, PrimCall, TailCall, OtherFundemental};
+	enum AST_exprType { Constant, Variable, Lambda, Branch, When, Definition, Assignment, Sequence, ProcCall, And, Or, PrimCall, TailCall, OtherFundemental};
 	enum AST_varRefType { Local, Free, Global };
 	typedef struct AST_expr { enum AST_exprType type; struct AST_const *value; char *variable; char **formal; int numFormals;
 		struct AST_expr **body; int numBody; char *primproc; struct AST_expr *proc; enum AST_varRefType varRefType; int varRefHop;

--- a/src/scoper.c
+++ b/src/scoper.c
@@ -42,7 +42,8 @@ AST_expr *scoper_scopeExpr(AST_expr *expr) {
 		case Constant: return expr;
 		case ProcCall:
 		case TailCall: expr->proc = scoper_scopeExpr(expr->proc); 
-		case Branch: 	
+		case Branch:
+		case When:
 		case Sequence: 	
 		case PrimCall: 	
 		case OtherFundemental:

--- a/src/treeshaker.c
+++ b/src/treeshaker.c
@@ -25,7 +25,8 @@ void treeshaker_shakeExpr(AST_expr *expr) {
 		case Constant: break;
 		case ProcCall:
 		case TailCall: treeshaker_shakeExpr(expr->proc); 
-		case Branch: 	
+		case Branch:
+		case When:
 		case Sequence: 	
 		case PrimCall: 
 		case OtherFundemental:	


### PR DESCRIPTION
I've got some cases where it would be very handy to use `when` instead of `if`+`begin`.

I took a stab at implementing it, but when I go to try it out on a device, the body seems to be skipped every time.

Do you think you could take a look and see if I'm making any obvious mistakes? I've tried combining elements from the codegen implementations of `Branch` and `Sequence` but something isn't right.

**Edit**: I found the problem; I misunderstood what `CPSE` was. My latest push seems to fix this, but the implementation is a bit tacky; it uses two `CPSE` instructions to simulate "Compare Skip Not Equal"; I'm sure there's a better way to do it.