### PR TITLE
Fix codegen_emit

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -163,7 +163,7 @@ void codegen_emit(AST_expr *expr, int parent_numArgs, FILE *outputFile)
                 // Nothing to do
                 return;
             }
-            break;
+            // fall through
 
         case Assignment:
             switch (expr->varRefType)


### PR DESCRIPTION
Remove a break added in commit e310e53c09d8bc18847f70791655f60e70271776 to
allow fall through, otherwise the code for Scheme definitions is not generated.